### PR TITLE
bugfix/Alt Description Button

### DIFF
--- a/npfphotosets.js
+++ b/npfphotosets.js
@@ -109,7 +109,7 @@ function npfPhotosets(selector, options) {
                             anchorImg.setAttribute("data-highres", anchors[l].getAttribute("data-big-photo"));
                             anchorImg.setAttribute("data-orig-width", anchors[l].getAttribute("data-big-photo-width"));
                             anchorImg.setAttribute("data-orig-height", anchors[l].getAttribute("data-big-photo-height"));
-                            currentPhotosetImages[k].appendChild(anchorImg);
+                            currentPhotosetImages[k].prepend(anchorImg);
                             anchors[l].remove();
                         }
                     }


### PR DESCRIPTION
Clicking the generated ALT button for descriptive text wouldn't trigger the expected box with descriptive text.
Issue was caused by image being appended to the end of the container instead of prepended; probably, the ALT button checks for the image previous to it, and not finding anything lead to error